### PR TITLE
Make query of .logtrail index compatible with ES 7.x

### DIFF
--- a/server/routes/server.js
+++ b/server/routes/server.js
@@ -298,7 +298,7 @@ function loadConfig(server) {
     const { callWithInternalUser } = server.plugins.elasticsearch.getCluster('admin');
     var request = {
       index: '.logtrail',
-      type: 'config',
+      type: '_doc',
       id: 1
     };
     callWithInternalUser('get',request).then(function (resp) {


### PR DESCRIPTION
As stated in https://www.elastic.co/guide/en/elasticsearch/reference/master/removal-of-types.html, when connecting to a elasticsearch version 7.x, operation GET /.logtrail/config/1 is no longer suported. It should be used GET /.logtrail/_doc/1 instead. I have tested this fix connecting to a ElasticSearch 7.3.2 and it works.